### PR TITLE
Implement range filters like "a=23..42"

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,17 @@
 [![NPM version](https://badge.fury.io/js/flora-ql.svg)](https://www.npmjs.com/package/flora-ql)
 [![Dependencies](https://img.shields.io/david/godmodelabs/flora-ql.svg)](https://david-dm.org/godmodelabs/flora-ql)
 
-Standalone Query Language parser used at the FLexible Open Rest Api with solid test coverage. 
-Define your own powerful syntax to use for example for filtering through your data. 
-It identifies the different parts of your input and returns these statements in 
-a two dimensional array resolved in disjunctive normal form.
+Standalone Query Language parser used at the FLexible Open Rest Api with solid test coverage. Define your own powerful syntax to use for example for filtering through your data. It identifies the different parts of your input and returns these statements in a two dimensional array resolved in disjunctive normal form.
 
 ## Features
 
 ### Statements
 
-A valid statement consists of three parts. An attribute, an operator and 
-the value. Attributes can be made up of multiple fields, connected with a dot 
-for example.
+A valid statement consists of three parts. An attribute, an operator and the value. Attributes can be made up of multiple fields, connected with a dot for example.
 
-```javascript
-var FloraQL = require('flora-ql');
+```js
+const FloraQL = require('flora-ql');
+
 FloraQL.setConfig('api');
 
 FloraQL.parse('id=321');
@@ -51,17 +47,16 @@ FloraQL.parse('user.description="I am the batman"');
 
 ### Logical connectives with round brackets
 
-Statements can be connected with AND and OR connectives. For the use of OR, it 
-is necessary to support round brackets. Deeply nested constructions are supported 
-as well and will be resolved.
+Statements can be connected with AND and OR connectives. For the use of OR, it is necessary to support round brackets. Deeply nested constructions are supported as well and will be resolved.
 
-```javascript
-var FloraQL = require('flora-ql');
+```js
+const FloraQL = require('flora-ql');
+
 FloraQL.setConfig('api');
 
 FloraQL.parse('id=321 AND user.id=109369');
 /*
- * [ [ 
+ * [ [
  *     { attribute: ['id'], operator: '=', value: 321 },
  *     { attribute: ['user', 'id'], operator: '=', value: 109369 }
  * ] ]
@@ -92,13 +87,11 @@ FloraQL.parse('id=321 AND (user.id=109369 OR user.id=109370)');
 
 ### Support for any operator and value
 
-The parser does not necessarily need to understand different operator types. Thus you 
-can use any operator you define. The values will be parsed, numbers will become numbers, 
-strings will remain strings and boolean/null/undefined will become their corresponding data 
-type. You can then use strictly equal operations on the value of every statement. 
+The parser does not necessarily need to understand different operator types. Thus you can use any operator you define. The values will be parsed, numbers will become numbers, strings will remain strings and boolean/null/undefined will become their corresponding data type. You can then use strictly equal operations on the value of every statement.
 
-```javascript
-var FloraQL = require('flora-ql');
+```js
+const FloraQL = require('flora-ql');
+
 FloraQL.setConfig('api');
 
 FloraQL.parse('type>9000 AND name="Bruce Wayne" AND incognito=true');
@@ -113,15 +106,13 @@ FloraQL.parse('type>9000 AND name="Bruce Wayne" AND incognito=true');
 
 ### Attribute grouping / scoping
 
-If you got multiple statements with similar attributes, you can shorten your query 
-by using square brackets for grouping/scoping. These can even be used between your 
-attributes and each bracket can itself contain deeply complex constructions with 
-more brackets and connectives.
+If you got multiple statements with similar attributes, you can shorten your query by using square brackets for grouping/scoping. These can even be used between your attributes and each bracket can itself contain deeply complex constructions with more brackets and connectives.
 
 In case you can think of a better terminology, please let us know. :)
 
-```javascript
-var FloraQL = require('flora-ql');
+```js
+const FloraQL = require('flora-ql');
+
 FloraQL.setConfig('api');
 
 FloraQL.parse('user[type>9000 AND name="Bruce Wayne"]');
@@ -145,13 +136,11 @@ FloraQL.parse('user[external OR internal].type=2');
 
 ### Human readable error statements
 
-Every operation is synchronous and will throw a custom error object named ArgumentError 
-if something is invalid. The message will provide additional information if possible 
-about the error type and position inside the query string. Every Error type has a 
-unique Error code as 'code' parameter and is available under /error/codes.json.
+Every operation is synchronous and will throw a custom error object named ArgumentError if something is invalid. The message will provide additional information if possible about the error type and position inside the query string. Every Error type has a unique Error code as 'code' parameter and is available under /error/codes.json.
 
-```javascript
-var FloraQL = require('flora-ql');
+```js
+const FloraQL = require('flora-ql');
+
 FloraQL.setConfig('api');
 
 try {
@@ -164,15 +153,10 @@ try {
 
 ### Highly customizable syntax
 
-Special characters used in the queries are defined by a .json file under /config. 
-There are already two predefined sets, called 'api' and 'alerting' and a default 
-configuration. You can either use one of them by passing the name as string to 
-setConfig() or provide an object with custom values which will extend the 
-default configuration.  
+Special characters used in the queries are defined by a .json file under /config. There are already two predefined sets, called 'api' and 'alerting' and a default configuration. You can either use one of them by passing the name as string to setConfig() or provide an object with custom values which will extend the default configuration.  
 
-
-```javascript
-var FloraQL = require('flora-ql');
+```js
+const FloraQL = require('flora-ql');
 
 FloraQL.setConfig({
     "operators": ["!=", "<=", ">=", "=", "<", ">"], // list of valid operators

--- a/beautify/index.js
+++ b/beautify/index.js
@@ -38,16 +38,26 @@ module.exports = function factory(cfg) {
                     if (cfg.validateStatements) {
                         assert(term.attribute !== null && term.attribute !== '', 2215, { stmnt: term.toString() });
                         assert(term.operator !== null && term.operator !== '', 2216, { stmnt: term.toString() });
-                        assert(term.value === null || term.value === '' || term.value.length !== 0, 2217, {
-                            stmnt: term.toString()
-                        });
+                        assert(
+                            term.value === null ||
+                                term.value === '' ||
+                                term.value.length !== 0 ||
+                                (term.range && term.range.length === 2),
+                            2217,
+                            {
+                                stmnt: term.toString()
+                            }
+                        );
                     }
 
-                    result[result.length - 1].push({
+                    const res = {
                         attribute: (term.attribute || '').split(config.glue),
-                        operator: term.operator,
-                        value: term.value
-                    });
+                        operator: term.operator
+                    };
+                    if (term.range && term.range.length === 2) res.range = term.range;
+                    else res.value = term.value;
+
+                    result[result.length - 1].push(res);
                 } else {
                     throw new ArgumentError(2202);
                 }

--- a/config/alerting.json
+++ b/config/alerting.json
@@ -7,6 +7,7 @@
     "string": "\"",
     "lookDelimiter": "|",
     "setDelimiter": ",",
+    "rangeDelimiter": "..",
     "roundBracket": ["(", ")"],
     "squareBracket": ["[", "]"],
 

--- a/config/api.json
+++ b/config/api.json
@@ -7,6 +7,7 @@
     "string": "\"",
     "lookDelimiter": " OR ",
     "setDelimiter": ",",
+    "rangeDelimiter": "..",
     "roundBracket": ["(", ")"],
     "squareBracket": ["[", "]"],
 

--- a/config/default.json
+++ b/config/default.json
@@ -7,6 +7,7 @@
     "string": "\"",
     "lookDelimiter": "+",
     "setDelimiter": ",",
+    "rangeDelimiter": "..",
     "roundBracket": ["(", ")"],
     "squareBracket": ["[", "]"],
 

--- a/config/index.js
+++ b/config/index.js
@@ -12,6 +12,7 @@ const defaults = require('./default');
  *     string:          string,
  *     lookDelimiter:   string|Array,
  *     setDelimiter:    string,
+ *     rangeDelimiter:  string,
  *     roundBracket:    Array,
  *     squareBracket:   Array
  * }} Config

--- a/error/codes.json
+++ b/error/codes.json
@@ -32,5 +32,6 @@
     "2214": "Invalid value type, missing string quotation marks for ':value'?",
     "2215": "Missing attribute in statement ':stmnt'",
     "2216": "Missing operator in statement ':stmnt'",
-    "2217": "Missing value in statement ':stmnt'"
+    "2217": "Missing value in statement ':stmnt'",
+    "2218": "Invalid range in near ':context' (pos: :index)"
 }

--- a/test/tokenizer/index.js
+++ b/test/tokenizer/index.js
@@ -88,6 +88,11 @@ describe('tokenizer()', function() {
             ['  a  [  (  b  =  1  )  ]  ',                                          'e0[(e1)]'],
             ['  a  [  (  b  =  1  +  c  =  1  )  ]  [  d  =  1  *  e  =  1  ]  ',   'e0[(e1+e2)][e3*e4]'],
 
+            // ranges
+
+            ['a=10..20',        'e0'],
+            ['a="10".."20"',    'e0'],
+
             // all the things!
 
             ['a=1*(b[(c=1)][(d="\\")(()][[].,"*e=1)]+f!=1)*g=1',                    'e0*(e1[(e2)][(e3*e4)]+e5)*e6']
@@ -107,7 +112,10 @@ describe('tokenizer()', function() {
             ['a=s"',            2212],
             ['a="s',            2213],
             ['a=s',             2214],
-            ['a=1 b=2',         2211]
+            ['a=1 b=2',         2211],
+            ['a=..3',           2214],
+            // ['a=3..',           2214], // TODO: same as 'a=1,'
+            ['a=1..2..3',       2218],
         ];
 
     function factory(config, input, output) {


### PR DESCRIPTION
This PR adds a new "rangeDelimiter" configuration (default: "..") that allows parsing of ranges.

```js
FloraQL.parse('age=18..45')
// [ [ { attribute: [ 'age' ], operator: '=', range: [ 18, 45 ] } ] ]

FloraQL.parse('date="2019-01-01".."2019-03-31"')
// [ [ { attribute: [ 'date' ], operator: '=', range: [ '2019-01-01', '2019-03-31' ] } ] ]
```

This works with any operator (which may or may not make sense, but this also holds for lists and has to be handled by the application).